### PR TITLE
close #9

### DIFF
--- a/build/webpack.prod.conf.js
+++ b/build/webpack.prod.conf.js
@@ -10,16 +10,15 @@ const webpackConfigBase = require('./webpack.base.conf');
 
 const webpackConfigProd = {
     mode: 'production', // 通过 mode 声明生产环境
-    
+
 	output: {
 		path: path.resolve(__dirname, '../dist'),
 		// 打包多出口文件
 		filename: './js/[name].[hash].js',
-		publicPath: './'
     },
-    
+
     devtool: 'cheap-module-eval-source-map',
-    
+
 	plugins: [
 		//删除dist目录
 		new cleanWebpackPlugin(['dist'], {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "local": "npm run dev --m local",
     "dev": "cross-env NODE_ENV=development webpack-dev-server --config build/webpack.dev.conf.js ",
     "build": "cross-env webpack --config build/webpack.prod.conf.js",
-    "server": "live-server ./ --port=8888"
+    "server": "live-server ./dist --port=8888"
   },
   "author": "lsy",
   "license": "ISC",


### PR DESCRIPTION
- 移除publicPath 
   - publicPath 导致 最后打包的文件page3.html/page4.html中引用js的文件路径发生错误，会以deep_page为准，产生错误的相对路径
"http://127.0.0.1:8888/deep_page/js/deep_page/page3.b81884bbfce60ced0244.js"
- 修改server路径
  - npm script server的路径设置会展示整个文件夹，如果从那里一层一层点进dist, 由于首页index.js里的链接href都是相对路径，会导致展示page2.html等其他页面时，从“http://127.0.0.1:8888/dist” 跳转到 “http://127.0.0.1:8888/page2.html” ，正确的应该是 “http://127.0.0.1:8888/dist/page2.html”
